### PR TITLE
Use the source video NALU start code length for rewriting the bitstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "0.20.2"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f682656975d3a682daff957be4ddeb65d6ad656737cd821f2d00685ae466af1"
+checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
 dependencies = [
  "funty",
  "radium 0.6.2",
@@ -80,7 +80,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c8044d3388c7201657372b870f2f443256bb7c26c95a482fca79da833e0c5b"
 dependencies = [
- "bitvec 0.20.2",
+ "bitvec 0.20.4",
 ]
 
 [[package]]
@@ -113,9 +113,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "regex",
  "terminal_size",
- "unicode-width",
  "winapi",
 ]
 
@@ -139,7 +137,7 @@ name = "dovi_tool"
 version = "0.3.2"
 dependencies = [
  "ansi_term 0.12.1",
- "bitvec 0.20.2",
+ "bitvec 0.20.4",
  "bitvec_helpers",
  "crc",
  "hevc_parser",
@@ -182,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "hevc_parser"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1452c5121c7a5a1b470c8951007952de86fadb56b6272cc4e6b7c8635b77f3b5"
+checksum = "c16aec90ce670cf71f08c3f2f3e40e3c854723928c7b611f14bb33b3dadb3256"
 dependencies = [
  "bitvec_helpers",
  "nom",
@@ -192,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.15.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
 dependencies = [
  "console",
  "lazy_static",
@@ -229,15 +227,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "nom"
@@ -254,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "number_prefix"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "proc-macro-error"
@@ -284,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -314,9 +312,9 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "regex"
-version = "1.4.5"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -325,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.23"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "ryu"
@@ -337,18 +335,18 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -404,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.69"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -421,9 +419,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "terminal_size"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
@@ -452,9 +450,9 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,12 @@ license = "MIT"
 
 [dependencies]
 structopt = "0.3.21"
-indicatif = "0.15.0"
-regex = "1.4.5"
+indicatif = "0.16.2"
+regex = "1.5.4"
 ansi_term = "0.12.1"
 crc = "2.0.0-rc.1"
 bitvec = "0.20.1"
 bitvec_helpers = "0.1.0"
-hevc_parser = "0.1.2"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+hevc_parser = "0.1.3"
+serde = { version = "1.0.126", features = ["derive"] }
+serde_json = "1.0.64"

--- a/src/dovi/io.rs
+++ b/src/dovi/io.rs
@@ -6,7 +6,7 @@ use indicatif::ProgressBar;
 use std::io::Read;
 
 use super::rpu::parse_dovi_rpu;
-use super::{Format, RpuOptions, OUT_NAL_HEADER};
+use super::{write_nal_header, Format, RpuOptions, OUT_NAL_HEADER};
 
 use hevc_parser::hevc::NALUnit;
 use hevc_parser::hevc::{NAL_UNSPEC62, NAL_UNSPEC63};
@@ -215,7 +215,7 @@ impl DoviReader {
                     continue;
                 }
 
-                sl_writer.write_all(OUT_NAL_HEADER)?;
+                write_nal_header(nal, sl_writer)?;
 
                 if nal.nal_type == NAL_UNSPEC62 {
                     if let Some(mode) = self.options.mode {
@@ -245,13 +245,13 @@ impl DoviReader {
             match nal.nal_type {
                 NAL_UNSPEC63 => {
                     if let Some(ref mut el_writer) = dovi_writer.el_writer {
-                        el_writer.write_all(OUT_NAL_HEADER)?;
+                        write_nal_header(nal, el_writer)?;
                         el_writer.write_all(&chunk[nal.start + 2..nal.end])?;
                     }
                 }
                 NAL_UNSPEC62 => {
                     if let Some(ref mut el_writer) = dovi_writer.el_writer {
-                        el_writer.write_all(OUT_NAL_HEADER)?;
+                        write_nal_header(nal, el_writer)?;
                     }
 
                     // No mode: Copy
@@ -295,7 +295,7 @@ impl DoviReader {
                 }
                 _ => {
                     if let Some(ref mut bl_writer) = dovi_writer.bl_writer {
-                        bl_writer.write_all(OUT_NAL_HEADER)?;
+                        write_nal_header(nal, bl_writer)?;
                         bl_writer.write_all(&chunk[nal.start..nal.end])?;
                     }
                 }


### PR DESCRIPTION
Would allow bit identical demux + inject compared to the original file.

Currently somehow the data contains extra zeroes, ending up with around 1 extra byte every ~7000 NALUs.
Demuxing also needs testing.