### PR TITLE
Add experimental HDR10+ source for generate

### DIFF
--- a/assets/generator_example.json
+++ b/assets/generator_example.json
@@ -1,6 +1,27 @@
 {
     "length": 1000,
-    "target_nits": 1000,
+    "level2": [
+        {
+            "target_nits": 100
+        },
+        {
+            "target_nits": 600
+        },
+        {
+            "target_nits": 1000,
+            "trim_power": 2096,
+            "trim_saturation_gain": 2128
+        },
+        {
+            "target_nits": 2000,
+            "trim_slope": 2048,
+            "trim_offset": 2048,
+            "trim_power": 2048,
+            "trim_chroma_weight": 2048,
+            "trim_saturation_gain": 2048,
+            "ms_weight": 2048
+        }
+    ],
     "level6": {
         "max_display_mastering_luminance": 1000,
         "min_display_mastering_luminance": 1,

--- a/assets/generator_example.json
+++ b/assets/generator_example.json
@@ -1,6 +1,6 @@
 {
     "length": 1000,
-    "target_nits": 600,
+    "target_nits": 1000,
     "level6": {
         "max_display_mastering_luminance": 1000,
         "min_display_mastering_luminance": 1,

--- a/generator.md
+++ b/generator.md
@@ -7,13 +7,31 @@ A JSON config example:
     "length": int,
 
     // Target nits for L2 metadata (0 to 10000).
-    // Usually 600, 1000 or 4000
+    // Usually 600, 1000, 2000
+    // Optional if specific L2 targets are present
     "target_nits": int,
 
     // Source min/max PQ values to override, optional
     // If not specified, derived from L6 metadata
     "source_min_pq": int,
     "source_max_pq": int,
+
+    // L2 metadata, optional
+    // If not specified, nothing added
+    // By default, trim adjustments are set to 2048 (no adjust)
+    "level2": [
+        {
+            "target_nits": 600,
+            "trim_slope": 2000,
+            "trim_saturation_gain": 2096
+        },
+        {
+            "target_nits": 1000
+        },
+        {
+            "target_nits": 2000
+        }
+    ],
 
     // L5 metadata, optional
     // If not specified, L5 metadata is added with 0 offsets

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -182,6 +182,13 @@ pub enum Command {
             parse(from_os_str)
         )]
         rpu_out: Option<PathBuf>,
+
+        #[structopt(
+            long,
+            help = "HDR10+ JSON file to generate from (experimental)",
+            parse(from_os_str)
+        )]
+        hdr10plus_json: Option<PathBuf>,
     },
 
     Export {

--- a/src/dovi/generator.rs
+++ b/src/dovi/generator.rs
@@ -1,8 +1,10 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::fs::File;
-use std::io::{BufWriter, Write};
+use std::io::{BufWriter, Read, Write};
 use std::path::PathBuf;
 
+use crate::dovi::rpu::nits_to_pq;
 use crate::dovi::OUT_NAL_HEADER;
 
 use super::DoviRpu;
@@ -14,6 +16,7 @@ use super::rpu::{
 pub struct Generator {
     json_path: PathBuf,
     rpu_out: PathBuf,
+    hdr10plus_path: Option<PathBuf>,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug)]
@@ -29,6 +32,12 @@ pub struct GenerateConfig {
 
     pub level5: Option<Level5Metadata>,
     pub level6: Option<Level6Metadata>,
+}
+
+pub struct Level1Metadata {
+    pub min_pq: u16,
+    pub max_pq: u16,
+    pub avg_pq: u16,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug)]
@@ -48,7 +57,7 @@ pub struct Level6Metadata {
 }
 
 impl Generator {
-    pub fn generate(json_path: PathBuf, rpu_out: Option<PathBuf>) {
+    pub fn generate(json_path: PathBuf, rpu_out: Option<PathBuf>, hdr10plus_path: Option<PathBuf>) {
         let out_path = if let Some(out_path) = rpu_out {
             out_path
         } else {
@@ -58,6 +67,7 @@ impl Generator {
         let generator = Generator {
             json_path,
             rpu_out: out_path,
+            hdr10plus_path,
         };
 
         let json_file = File::open(&generator.json_path).unwrap();
@@ -74,18 +84,48 @@ impl Generator {
 
     fn execute(&self, config: &GenerateConfig) -> Result<(), std::io::Error> {
         println!("Generating metadata...");
-        let mut rpu = DoviRpu {
-            dovi_profile: 8,
-            modified: true,
-            header: RpuDataHeader::p8_default(),
-            vdr_rpu_data: Some(VdrRpuData::p8_default()),
-            nlq_data: None,
-            vdr_dm_data: Some(VdrDmData::from_config(config)),
-            last_byte: 0x80,
-            ..Default::default()
-        };
 
-        let encoded_rpu = rpu.write_rpu_data();
+        let mut l1_meta: Option<Vec<Level1Metadata>> = None;
+
+        if let Some(path) = &self.hdr10plus_path {
+            let mut s = String::new();
+            File::open(path).unwrap().read_to_string(&mut s).unwrap();
+
+            let hdr10plus: Value = serde_json::from_str(&s).unwrap();
+
+            if let Some(json) = hdr10plus.as_object() {
+                if let Some(scene_info) = json.get("SceneInfo") {
+                    if let Some(list) = scene_info.as_array() {
+                        let info_list = list
+                            .iter()
+                            .filter_map(|e| e.as_object())
+                            .map(|e| {
+                                let lum_v = e.get("LuminanceParameters").unwrap();
+                                let lum = lum_v.as_object().unwrap();
+
+                                let avg_rgb = lum.get("AverageRGB").unwrap().as_u64().unwrap();
+                                let maxscl = lum.get("MaxScl").unwrap().as_array().unwrap();
+
+                                let max_rgb =
+                                    maxscl.iter().filter_map(|e| e.as_u64()).max().unwrap();
+
+                                Level1Metadata {
+                                    min_pq: 0,
+                                    max_pq: (nits_to_pq((max_rgb as f64 / 10.0).round() as u16)
+                                        * 4095.0)
+                                        .round() as u16,
+                                    avg_pq: (nits_to_pq((avg_rgb as f64 / 10.0).round() as u16)
+                                        * 4095.0)
+                                        .round() as u16,
+                                }
+                            })
+                            .collect();
+
+                        l1_meta = Some(info_list)
+                    }
+                }
+            }
+        }
 
         println!("Writing RPU file...");
         let mut writer = BufWriter::with_capacity(
@@ -93,7 +133,36 @@ impl Generator {
             File::create(&self.rpu_out).expect("Can't create file"),
         );
 
-        for _ in 0..config.length {
+        let length = if let Some(l1) = &l1_meta {
+            l1.len()
+        } else {
+            config.length as usize
+        };
+
+        for i in 0..length {
+            let mut rpu = DoviRpu {
+                dovi_profile: 8,
+                modified: true,
+                header: RpuDataHeader::p8_default(),
+                vdr_rpu_data: Some(VdrRpuData::p8_default()),
+                nlq_data: None,
+                vdr_dm_data: Some(VdrDmData::from_config(config)),
+                last_byte: 0x80,
+                ..Default::default()
+            };
+
+            let encoded_rpu = if let Some(l1_list) = &l1_meta {
+                if let Some(meta) = &l1_list.get(i) {
+                    if let Some(dm_meta) = &mut rpu.vdr_dm_data {
+                        dm_meta.add_level1_metadata(meta.min_pq, meta.max_pq, meta.avg_pq);
+                    }
+                }
+
+                rpu.write_rpu_data()
+            } else {
+                rpu.write_rpu_data()
+            };
+
             writer.write_all(OUT_NAL_HEADER)?;
 
             // Remove 0x7C01

--- a/src/dovi/rpu/tests.rs
+++ b/src/dovi/rpu/tests.rs
@@ -205,7 +205,7 @@ fn generated_rpu() {
 
     let config = GenerateConfig {
         length: 1000,
-        target_nits: 600,
+        target_nits: Some(600),
         source_min_pq: None,
         source_max_pq: None,
         level5: None,
@@ -215,6 +215,7 @@ fn generated_rpu() {
             max_content_light_level: 1000,
             max_frame_average_light_level: 400,
         }),
+        ..Default::default()
     };
 
     let vdr_dm_data = VdrDmData::from_config(&config);

--- a/src/dovi/rpu/vdr_dm_data.rs
+++ b/src/dovi/rpu/vdr_dm_data.rs
@@ -460,6 +460,25 @@ impl VdrDmData {
             ExtMetadataBlock::Reserved(b) => (b.block_info.ext_block_level, 0),
         })
     }
+
+    pub fn add_level1_metadata(&mut self, min_pq: u16, max_pq: u16, avg_pq: u16) {
+        let ext_metadata_block_level1 = ExtMetadataBlockLevel1 {
+            block_info: BlockInfo {
+                ext_block_length: 5,
+                ext_block_level: 1,
+                remaining: BitVec::from_bitslice(bits![Msb0, u8; 0; 4]),
+            },
+            min_pq,
+            max_pq,
+            avg_pq,
+        };
+
+        self.ext_metadata_blocks
+            .push(ExtMetadataBlock::Level1(ext_metadata_block_level1));
+        self.num_ext_blocks = self.ext_metadata_blocks.len() as u64;
+
+        self.sort_extension_blocks();
+    }
 }
 
 impl ExtMetadataBlock {

--- a/src/dovi/rpu/vdr_dm_data.rs
+++ b/src/dovi/rpu/vdr_dm_data.rs
@@ -479,6 +479,10 @@ impl VdrDmData {
 
         self.sort_extension_blocks();
     }
+
+    pub fn set_scene_cut(&mut self, is_scene_cut: bool) {
+        self.scene_refresh_flag = is_scene_cut as u64;
+    }
 }
 
 impl ExtMetadataBlock {

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,11 @@ fn main() {
             output,
         } => RpuInjector::inject_rpu(input, rpu_in, output),
         Command::Info { input, frame } => RpuInfo::info(input, frame),
-        Command::Generate { json_file, rpu_out } => Generator::generate(json_file, rpu_out),
+        Command::Generate {
+            json_file,
+            rpu_out,
+            hdr10plus_json,
+        } => Generator::generate(json_file, rpu_out, hdr10plus_json),
         Command::Export { input, output } => Exporter::export(input, output),
     }
 }


### PR DESCRIPTION
Allows using an HDR10+ JSON file to generate an RPU from..
Currently only tries calculating the L1 metadata.

I haven't really been able to match Dolby Vision values with HDR10+, so the conversion is possibly wrong.