### PR TITLE
Fix L1/L2 calculation

### DIFF
--- a/dolby_vision/src/st2094_10/metadata_blocks/level2.rs
+++ b/dolby_vision/src/st2094_10/metadata_blocks/level2.rs
@@ -28,7 +28,7 @@ impl ExtMetadataBlockLevel2 {
             trim_power: reader.get_n(12),
             trim_chroma_weight: reader.get_n(12),
             trim_saturation_gain: reader.get_n(12),
-            ms_weight: reader.get_n::<u16>(13) as i16,
+            ms_weight: |i| -> i16 {if i > 4095 {-1} else {i}} (reader.get_n::<u16>(13) as i16),
         })
     }
 

--- a/dolby_vision/src/st2094_10/mod.rs
+++ b/dolby_vision/src/st2094_10/mod.rs
@@ -103,7 +103,7 @@ impl ST2094_10Meta {
             trim_power: level2_config.trim_power,
             trim_chroma_weight: level2_config.trim_chroma_weight,
             trim_saturation_gain: level2_config.trim_saturation_gain,
-            ms_weight: level2_config.ms_weight,
+            ms_weight: level2_config.ms_weight.clamp(-1, 4095),
         };
 
         self.ext_metadata_blocks

--- a/dolby_vision/src/xml/parser.rs
+++ b/dolby_vision/src/xml/parser.rs
@@ -552,17 +552,21 @@ impl CmXmlParser {
 
         ensure!(trim.len() == 9, "invalid L2 trim: should be 9 values");
 
+        let trim_lift = trim[3].parse::<f32>().unwrap();
+        let trim_gain = trim[4].parse::<f32>().unwrap();
+        let trim_gamma = trim[5].parse::<f32>().unwrap().clamp(-1.0, 1.0);
+
         let trim_slope = min(
             4095,
-            ((trim[4].parse::<f32>().unwrap() * 2048.0) + 2048.0).round() as u16,
+            ((((trim_gain + 2.0) * (1.0 - trim_lift / 2.0) - 2.0) * 2048.0) + 2048.0).round() as u16,
         );
         let trim_offset = min(
             4095,
-            ((trim[3].parse::<f32>().unwrap() * 2048.0) + 2048.0).round() as u16,
+            ((((trim_gain + 2.0) * (trim_lift / 2.0)) * 2048.0) + 2048.0).round() as u16,
         );
         let trim_power = min(
             4095,
-            ((trim[5].parse::<f32>().unwrap() * -2048.0) + 2048.0).round() as u16,
+            (((2.0 / (1.0 + trim_gamma / 2.0) - 2.0) * 2048.0) + 2048.0).round() as u16,
         );
         let trim_chroma_weight = min(
             4095,

--- a/src/dovi/generator.rs
+++ b/src/dovi/generator.rs
@@ -319,7 +319,7 @@ fn parse_hdr10plus_for_l1(
 
                         // Clamp
                         max_pq = min(max(max_pq, L1_MAX_PQ_MIN_VALUE), L1_MAX_PQ_MAX_VALUE);
-                        avg_pq = min(max(avg_pq, L1_AVG_PQ_MIN_VALUE), max_pq);
+                        avg_pq = min(max(avg_pq, L1_AVG_PQ_MIN_VALUE), max_pq - 1);
 
                         Level1Metadata {
                             min_pq,


### PR DESCRIPTION
In Dolby Vision Metadata XML, Level 2 metadata entries are:
Reserved1, Reserved2, Reserved3, **Lift, Gain, Gamma**, Saturation, Chroma and Tone Detail.
However, in RPU data, they are presented as:
**trim_slope, trim_offset, trim_power**, trim_chroma_weight, trim_saturation_gain and ms_weight
They're Slope-Offset-Power (SOP) parameters, while the original values are Lift-Gamma-Gain (LGG) parameters, they are not corresponded directly, a transformation is needed.

About ms_weight:
It's a 13-bit signed integer, but the only possible negative value is -1 (as noted in the patent), just set to -1 if the 16-bit signed integer casted from bits is above 4095, also add a clamp when parse data from json.