### PR TITLE
Converter default output

### DIFF
--- a/src/dovi/converter.rs
+++ b/src/dovi/converter.rs
@@ -39,7 +39,10 @@ impl Converter {
 
         let output = match output {
             Some(path) => path,
-            None => PathBuf::from("BL_EL.hevc"),
+            None => match options.discard_el {
+                true => PathBuf::from("BL_RPU.hevc"),
+                false => PathBuf::from("BL_EL_RPU.hevc"),
+            },
         };
 
         let demuxer = Converter::new(format, input, output);


### PR DESCRIPTION
This fixes #97 to dynamically set the filename output for the converter based on the presence/absence of the `--discard` option.

I'd personally prefer to see "RPU" explicitly included in the filenames to indicate where/when it's present in an HEVC stream, but I understand if your sense is that it should be obvious that it's carried with the EL when present or with the BL when not.

So I went with `BL_RPU.hevc` when `--discard` is used and `BL_EL_RPU.hevc` when not.

I could easily change it if your preference is for `BL.hevc` with `--discard` and `BL_EL.hevc` without.


### Testing
- I compiled, ran, and tested the changes with and without `--discard`
- `dovi_tool -m 2 convert --discard duallayer.hevc` outputs `BL_RPU.hevc`
- `dovi_tool -m 2 convert duallayer.hevc` outputs `BL_EL_RPU.hevc`