### PR TITLE
Use C-string literals for EL type in C-API

### DIFF
--- a/dolby_vision/src/c_structs/rpu_data_header.rs
+++ b/dolby_vision/src/c_structs/rpu_data_header.rs
@@ -1,5 +1,5 @@
 use libc::c_char;
-use std::{ffi::CString, ptr::null};
+use std::ptr::null;
 
 use crate::rpu::rpu_data_header::RpuDataHeader as RuRpuDataHeader;
 
@@ -41,16 +41,6 @@ pub struct RpuDataHeader {
     vdr_dm_metadata_present_flag: bool,
     use_prev_vdr_rpu_flag: bool,
     prev_vdr_rpu_id: u64,
-}
-
-impl RpuDataHeader {
-    /// # Safety
-    /// The buffer pointers should be valid.
-    pub unsafe fn free(&self) {
-        if !self.el_type.is_null() {
-            drop(CString::from_raw(self.el_type as *mut c_char));
-        }
-    }
 }
 
 impl From<&RuRpuDataHeader> for RpuDataHeader {

--- a/dolby_vision/src/c_structs/rpu_data_nlq.rs
+++ b/dolby_vision/src/c_structs/rpu_data_nlq.rs
@@ -1,4 +1,12 @@
-use crate::rpu::{rpu_data_nlq::RpuDataNlq as RuRpuDataNlq, NUM_COMPONENTS};
+use std::ffi::CStr;
+
+use crate::rpu::{
+    rpu_data_nlq::{DoviELType, RpuDataNlq as RuRpuDataNlq},
+    NUM_COMPONENTS,
+};
+
+const FEL_CSTR: &CStr = c"FEL";
+const MEL_CSTR: &CStr = c"MEL";
 
 /// C struct for rpu_data_nlq()
 #[repr(C)]
@@ -10,6 +18,15 @@ pub struct RpuDataNlq {
     linear_deadzone_slope: [u64; NUM_COMPONENTS],
     linear_deadzone_threshold_int: [u64; NUM_COMPONENTS],
     linear_deadzone_threshold: [u64; NUM_COMPONENTS],
+}
+
+impl DoviELType {
+    pub const fn as_cstr(&self) -> &'static CStr {
+        match self {
+            DoviELType::MEL => MEL_CSTR,
+            DoviELType::FEL => FEL_CSTR,
+        }
+    }
 }
 
 impl From<&RuRpuDataNlq> for RpuDataNlq {

--- a/dolby_vision/src/capi.rs
+++ b/dolby_vision/src/capi.rs
@@ -214,7 +214,7 @@ pub unsafe extern "C" fn dovi_rpu_get_header(ptr: *const RpuOpaque) -> *const Rp
         let mut header = RpuDataHeader::from(&rpu.header);
 
         if let Some(el_type) = rpu.el_type.as_ref() {
-            header.el_type = CString::new(el_type.as_str()).unwrap().into_raw();
+            header.el_type = el_type.as_cstr().as_ptr();
         }
 
         Box::into_raw(Box::new(header))
@@ -230,8 +230,7 @@ pub unsafe extern "C" fn dovi_rpu_get_header(ptr: *const RpuOpaque) -> *const Rp
 #[no_mangle]
 pub unsafe extern "C" fn dovi_rpu_free_header(ptr: *const RpuDataHeader) {
     if !ptr.is_null() {
-        let header = Box::from_raw(ptr as *mut RpuDataHeader);
-        header.free();
+        drop(Box::from_raw(ptr as *mut RpuDataHeader));
     }
 }
 


### PR DESCRIPTION
Requires bumping MSRV.