### PR TITLE
Editor: add allow_cmv4_transfer option for experimental CMv4.0 → CMv2.9 level transfer

### DIFF
--- a/docs/editor.md
+++ b/docs/editor.md
@@ -132,5 +132,14 @@ The editor expects a JSON config like the example below:
     // Levels to replace using metadata from `source_rpu`
     // List of integers representing block levels
     "rpu_levels": int[],
+
+    // EXPERIMENTAL: Allows transferring CM v4.0 levels (L3, L8, L9, L10, L11, L254) to CM v2.9 RPU.
+    // This implicitly converts the input RPU to CM v4.0 format, with default L254.
+    //
+    // WARNING: This is not normally allowed and may lead to playback issues (e.g., if L8 is not transferred).
+    // Intended for advanced/experimental workflows only. Use at your own risk.
+    //
+    // Default: false
+    "allow_cmv4_transfer": boolean,
 }
 ```


### PR DESCRIPTION
This MR adds an experimental `allow_cmv4_transfer` option to the `editor` command.

When enabled, it allows transferring `CM v4.0` levels to a `CM v2.9` **RPU**.
Internally, the input **RPU** is implicitly **converted** to `CM v4.0` (with only a default **L254** added).

The option is explicitly marked as experimental.

It is intended strictly for advanced hybrid workflows, such as:
- injecting `CM v4.0` metadata into a `CM v2.9` **RPU** (e.g., for Blu-ray-based **hybrid RPUs**),
- simplifying current multi-step hybrid generation pipelines — for example, in [Dovi Scripts](https://github.com/R3S3t9999/DoVi_Scripts), where a modified `dovi_tool 1.5.3` performs `convert_to_cmv4` before a newer `dovi_tool` transfers levels.