### PR TITLE
Add L2/L8 plots and extend summary info/plots with L5 offsets, L8 trims, and L9 MDP

### DIFF
--- a/dolby_vision/src/rpu/extension_metadata/blocks/level5.rs
+++ b/dolby_vision/src/rpu/extension_metadata/blocks/level5.rs
@@ -12,7 +12,7 @@ const MAX_RESOLUTION_13_BITS: u16 = 8191;
 
 /// Active area of the picture (letterbox, aspect ratio)
 #[repr(C)]
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct ExtMetadataBlockLevel5 {
     pub active_area_left_offset: u16,

--- a/dolby_vision/src/rpu/extension_metadata/blocks/level8.rs
+++ b/dolby_vision/src/rpu/extension_metadata/blocks/level8.rs
@@ -148,6 +148,18 @@ impl ExtMetadataBlockLevel8 {
 
         Ok(())
     }
+
+    pub fn trim_target_nits(&self) -> u16 {
+        match self.target_display_index {
+            16 | 18 | 21 => 48,
+            42 => 108,
+            24 | 25 => 300,
+            27 | 28 => 600,
+            48 | 49 => 1000,
+            37 | 38 => 2000,
+            _ => 100,
+        }
+    }
 }
 
 impl ExtMetadataBlockInfo for ExtMetadataBlockLevel8 {

--- a/dolby_vision/src/rpu/extension_metadata/primaries.rs
+++ b/dolby_vision/src/rpu/extension_metadata/primaries.rs
@@ -50,6 +50,23 @@ pub enum MasteringDisplayPrimaries {
     SGamut3Cine,
 }
 
+impl MasteringDisplayPrimaries {
+    pub fn u8_to_alias(value: u8) -> Option<&'static str> {
+        match value {
+            0 => Some("DCI-P3 D65"),
+            1 => Some("BT.709"),
+            2 => Some("BT.2020"),
+            3 => Some("SMPTE-C"),
+            4 => Some("BT.601"),
+            5 => Some("DCI-P3"),
+            6 => Some("ACES"),
+            7 => Some("S-Gamut"),
+            8 => Some("S-Gamut-3.Cine"),
+            _ => None,
+        }
+    }
+}
+
 impl ColorPrimaries {
     pub fn from_array_int(primaries: &[u16; 8]) -> ColorPrimaries {
         Self {

--- a/dolby_vision/src/rpu/extension_metadata/primaries.rs
+++ b/dolby_vision/src/rpu/extension_metadata/primaries.rs
@@ -50,20 +50,37 @@ pub enum MasteringDisplayPrimaries {
     SGamut3Cine,
 }
 
-impl MasteringDisplayPrimaries {
-    pub fn u8_to_alias(value: u8) -> Option<&'static str> {
+impl From<u8> for MasteringDisplayPrimaries {
+    fn from(value: u8) -> Self {
         match value {
-            0 => Some("DCI-P3 D65"),
-            1 => Some("BT.709"),
-            2 => Some("BT.2020"),
-            3 => Some("SMPTE-C"),
-            4 => Some("BT.601"),
-            5 => Some("DCI-P3"),
-            6 => Some("ACES"),
-            7 => Some("S-Gamut"),
-            8 => Some("S-Gamut-3.Cine"),
-            _ => None,
+            0 => Self::DCIP3D65,
+            1 => Self::BT709,
+            2 => Self::BT2020,
+            3 => Self::SMPTEC,
+            4 => Self::BT601,
+            5 => Self::DCIP3,
+            6 => Self::ACES,
+            7 => Self::SGamut,
+            8 => Self::SGamut3Cine,
+            _ => Self::DCIP3D65,
         }
+    }
+}
+
+impl std::fmt::Display for MasteringDisplayPrimaries {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let alias = match self {
+            Self::DCIP3D65 => "DCI-P3 D65",
+            Self::BT709 => "BT.709",
+            Self::BT2020 => "BT.2020",
+            Self::SMPTEC => "SMPTE-C",
+            Self::BT601 => "BT.601",
+            Self::DCIP3 => "DCI-P3",
+            Self::ACES => "ACES",
+            Self::SGamut => "S-Gamut",
+            Self::SGamut3Cine => "S-Gamut-3.Cine",
+        };
+        write!(f, "{}", alias)
     }
 }
 

--- a/dolby_vision/src/utils.rs
+++ b/dolby_vision/src/utils.rs
@@ -33,6 +33,12 @@ pub fn nits_to_pq(nits: f64) -> f64 {
         .powf(ST2084_M2)
 }
 
+/// Helper function to calculate PQ codes from nits (cd/m2) values
+#[inline(always)]
+pub fn nits_to_pq_12_bit(nits: f64) -> u16 {
+    (nits_to_pq(nits) * 4095.0).round() as u16
+}
+
 /// Copied from hevc_parser for convenience, and to avoid a dependency
 /// Unescapes a byte slice from annexb.
 /// Allocates a new Vec.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -57,7 +57,7 @@ pub enum Commands {
     #[command(about = "Interleaves the enhancement layer into a base layer HEVC bitstream")]
     Mux(MuxArgs),
 
-    #[command(about = "Plot the L1 dynamic brightness metadata")]
+    #[command(about = "Plot the L1/L2/L8 metadata")]
     Plot(PlotArgs),
 
     #[command(about = "Removes the enhancement layer and RPU data from the video")]

--- a/src/commands/plot.rs
+++ b/src/commands/plot.rs
@@ -1,4 +1,4 @@
-use crate::dovi::plotter::PlotType;
+use crate::dovi::plotter::{PlotType, TrimsFilter};
 use clap::{Args, ValueHint};
 use std::path::PathBuf;
 
@@ -49,4 +49,20 @@ pub struct PlotArgs {
         default_value = "l1"
     )]
     pub plot_type: PlotType,
+
+    #[arg(
+        long = "target-nits",
+        help = "Target brightness in nits for L2/L8 plots",
+        default_value = "100",
+        value_parser = ["100", "300", "600", "1000"]
+    )]
+    pub target_nits_str: String,
+
+    #[arg(
+        long,
+        help = "Parameters to exclude from L2/L8 trims plots\nSupports multiple occurrences prefixed by --trims-filter or delimited by ','",
+        value_enum,
+        value_delimiter = ','
+    )]
+    pub trims_filter: Vec<TrimsFilter>,
 }

--- a/src/commands/plot.rs
+++ b/src/commands/plot.rs
@@ -39,4 +39,7 @@ pub struct PlotArgs {
 
     #[arg(long, short = 'e', help = "Set frame range end (inclusive)")]
     pub end: Option<usize>,
+
+    #[arg(long, help = "Plot L2 trims metadata instead of L1 dynamic brightness")]
+    pub l2: bool,
 }

--- a/src/commands/plot.rs
+++ b/src/commands/plot.rs
@@ -1,3 +1,4 @@
+use crate::dovi::plotter::PlotType;
 use clap::{Args, ValueHint};
 use std::path::PathBuf;
 
@@ -40,6 +41,12 @@ pub struct PlotArgs {
     #[arg(long, short = 'e', help = "Set frame range end (inclusive)")]
     pub end: Option<usize>,
 
-    #[arg(long, help = "Plot L2 trims metadata instead of L1 dynamic brightness")]
-    pub l2: bool,
+    #[arg(
+        long,
+        short = 'p',
+        help = "Sets the DV metadata level to plot",
+        value_enum,
+        default_value = "l1"
+    )]
+    pub plot_type: PlotType,
 }

--- a/src/dovi/plotter.rs
+++ b/src/dovi/plotter.rs
@@ -10,7 +10,7 @@ use plotters::coord::ranged1d::{KeyPointHint, NoDefaultFormatting, Ranged, Value
 use plotters::coord::types::RangedCoordusize;
 use plotters::prelude::{
     AreaSeries, BitMapBackend, Cartesian2d, ChartBuilder, ChartContext, IntoDrawingArea,
-    PathElement, SeriesLabelPosition, WHITE,
+    LineSeries, PathElement, SeriesLabelPosition, WHITE,
 };
 use plotters::style::{BLACK, Color, IntoTextStyle, RGBColor, ShapeStyle};
 
@@ -18,7 +18,7 @@ use dolby_vision::rpu::utils::parse_rpu_file;
 use dolby_vision::utils::{nits_to_pq, pq_to_nits};
 
 use super::input_from_either;
-use super::rpu_info::RpusListSummary;
+use super::rpu_info::{L2Data, RpusListSummary};
 use crate::commands::PlotArgs;
 
 #[cfg(not(feature = "system-font"))]
@@ -56,10 +56,13 @@ impl Plotter {
             title,
             start: start_arg,
             end: end_arg,
+            l2,
         } = args;
 
-        let output = output.unwrap_or(PathBuf::from("L1_plot.png"));
-        let title = title.unwrap_or(String::from("Dolby Vision L1 plot"));
+        let (level, y_desc) = if l2 { (2, "") } else { (1, "nits (cd/m²)") };
+
+        let output = output.unwrap_or(PathBuf::from(format!("L{level}_plot.png")));
+        let title = title.unwrap_or(format!("Dolby Vision L{level} plot"));
 
         let input = input_from_either("info", input, input_pos)?;
         let plotter = Plotter { input };
@@ -81,13 +84,17 @@ impl Plotter {
             .titled(&title, ("sans-serif", 40))?;
 
         println!("Plotting...");
-        let summary = RpusListSummary::new(rpus)?;
+        let summary = if l2 {
+            RpusListSummary::with_l2_data(rpus)?
+        } else {
+            RpusListSummary::new(rpus)?
+        };
 
         let mut chart = ChartBuilder::on(&root)
             .x_label_area_size(60)
             .y_label_area_size(60)
             .margin_top(90)
-            .build_cartesian_2d(x_spec, PqCoord {})?;
+            .build_cartesian_2d(x_spec, PqCoord::for_level(level))?;
 
         chart
             .configure_mesh()
@@ -98,10 +105,15 @@ impl Plotter {
             .x_desc("frames")
             .x_max_light_lines(1)
             .x_labels(24)
-            .y_desc("nits (cd/m²)")
+            .y_desc(y_desc)
             .draw()?;
 
-        Self::draw_l1_series(&mut chart, &summary)?;
+        if l2 {
+            Self::draw_l2_series(&mut chart, &summary)?;
+        } else {
+            Self::draw_l1_series(&mut chart, &summary)?;
+        }
+
         chart
             .configure_series_labels()
             .border_style(BLACK)
@@ -239,49 +251,155 @@ impl Plotter {
 
         Ok(())
     }
+
+    fn draw_l2_series(
+        chart: &mut ChartContext<BitMapBackend, Cartesian2d<RangedCoordusize, PqCoord>>,
+        summary: &RpusListSummary,
+    ) -> Result<()> {
+        let data = summary.l2_data.as_ref().unwrap();
+        let l2_stats = summary.l2_stats.as_ref().unwrap();
+
+        type Series = (&'static str, fn(&L2Data) -> f64, (f64, f64, f64), RGBColor);
+        let series: [Series; 6] = [
+            (
+                "slope (gain)",
+                |e| e.0 as f64,
+                l2_stats.slope,
+                RGBColor(96, 158, 232), // blue
+            ),
+            (
+                "offset (lift)",
+                |e| e.1 as f64,
+                l2_stats.offset,
+                RGBColor(230, 110, 132), // pink
+            ),
+            (
+                "power (gamma)",
+                |e| e.2 as f64,
+                l2_stats.power,
+                RGBColor(236, 162, 75), // orange
+            ),
+            (
+                "chroma (weight)",
+                |e| e.3 as f64,
+                l2_stats.chroma,
+                RGBColor(115, 187, 190), // cyan
+            ),
+            (
+                "saturation (gain)",
+                |e| e.4 as f64,
+                l2_stats.saturation,
+                RGBColor(144, 106, 252), // purple
+            ),
+            (
+                "ms (weight)",
+                |e| e.5 as f64,
+                l2_stats.ms_weight,
+                RGBColor(243, 205, 95), // yellow
+            ),
+        ];
+
+        for (name, field_extractor, stats, color) in series.iter() {
+            let label = format!(
+                "{name} (min: {:.0}, max: {:.0}, avg: {:.0})",
+                stats.0, stats.1, stats.2
+            );
+            let series = LineSeries::new(
+                (0..).zip(data.iter()).map(|(x, y)| (x, field_extractor(y))),
+                color,
+            );
+            let shape_style = ShapeStyle {
+                color: color.to_rgba(),
+                filled: false,
+                stroke_width: 2,
+            };
+
+            chart
+                .draw_series(series)?
+                .label(label)
+                .legend(move |(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], shape_style));
+        }
+
+        Ok(())
+    }
 }
 
-pub struct PqCoord {}
+pub struct PqCoord {
+    key_points: Vec<f64>,
+    range: Range<f64>,
+    mapper: fn(&f64, (i32, i32)) -> i32,
+    formatter: fn(&f64) -> String,
+}
+
+impl PqCoord {
+    pub fn for_level(level: u8) -> PqCoord {
+        if level == 2 {
+            PqCoord {
+                key_points: vec![
+                    0.0, 512.0, 1024.0, 1536.0, 2048.0, 2560.0, 3072.0, 3584.0, 4096.0,
+                ],
+                range: 0_f64..4096.0_f64,
+                mapper: |value, limit| {
+                    let norm = value / 4096.0;
+                    let size = limit.1 - limit.0;
+                    (norm * size as f64).round() as i32 + limit.0
+                },
+                formatter: |value| format!("{value}"),
+            }
+        } else {
+            PqCoord {
+                key_points: vec![
+                    nits_to_pq(0.01),
+                    nits_to_pq(0.1),
+                    nits_to_pq(0.5),
+                    nits_to_pq(1.0),
+                    nits_to_pq(2.5),
+                    nits_to_pq(5.0),
+                    nits_to_pq(10.0),
+                    nits_to_pq(25.0),
+                    nits_to_pq(50.0),
+                    nits_to_pq(100.0),
+                    nits_to_pq(200.0),
+                    nits_to_pq(400.0),
+                    nits_to_pq(600.0),
+                    nits_to_pq(1000.0),
+                    nits_to_pq(2000.0),
+                    nits_to_pq(4000.0),
+                    nits_to_pq(10000.0),
+                ],
+                range: 0_f64..1.0_f64,
+                mapper: |value, limit| {
+                    let size = limit.1 - limit.0;
+                    (*value * size as f64) as i32 + limit.0
+                },
+                formatter: |value| {
+                    let nits = (pq_to_nits(*value) * 1000.0).round() / 1000.0;
+                    format!("{nits}")
+                },
+            }
+        }
+    }
+}
 
 impl Ranged for PqCoord {
     type FormatOption = NoDefaultFormatting;
     type ValueType = f64;
 
     fn map(&self, value: &f64, limit: (i32, i32)) -> i32 {
-        let size = limit.1 - limit.0;
-        (*value * size as f64) as i32 + limit.0
+        (self.mapper)(value, limit)
     }
 
     fn key_points<Hint: KeyPointHint>(&self, _hint: Hint) -> Vec<f64> {
-        vec![
-            nits_to_pq(0.01),
-            nits_to_pq(0.1),
-            nits_to_pq(0.5),
-            nits_to_pq(1.0),
-            nits_to_pq(2.5),
-            nits_to_pq(5.0),
-            nits_to_pq(10.0),
-            nits_to_pq(25.0),
-            nits_to_pq(50.0),
-            nits_to_pq(100.0),
-            nits_to_pq(200.0),
-            nits_to_pq(400.0),
-            nits_to_pq(600.0),
-            nits_to_pq(1000.0),
-            nits_to_pq(2000.0),
-            nits_to_pq(4000.0),
-            nits_to_pq(10000.0),
-        ]
+        self.key_points.clone()
     }
 
     fn range(&self) -> Range<f64> {
-        0_f64..1.0_f64
+        self.range.clone()
     }
 }
 
 impl ValueFormatter<f64> for PqCoord {
     fn format_ext(&self, value: &f64) -> String {
-        let nits = (pq_to_nits(*value) * 1000.0).round() / 1000.0;
-        format!("{nits}")
+        (self.formatter)(value)
     }
 }

--- a/src/dovi/plotter.rs
+++ b/src/dovi/plotter.rs
@@ -157,14 +157,25 @@ impl Plotter {
             (60, 60),
         )?;
 
+        let mut right_captions = vec![format!("L5 offsets: {}", summary.l5_str)];
         if !summary.l2_trims.is_empty() {
-            let caption = format!("L2 trims: {}", summary.l2_trims.join(", "));
-            let pos = (
-                (root.dim_in_pixel().0 - root.estimate_text_size(&caption, &caption_style)?.0)
-                    as i32,
-                60,
-            );
-            root.draw_text(&caption, &caption_style, pos)?;
+            right_captions.push(format!("L2 trims: {}", summary.l2_trims.join(", ")));
+        }
+        if let Some(l8_trims) = summary.l8_trims.filter(|v| !v.is_empty()) {
+            right_captions.push(format!("L8 trims: {}", l8_trims.join(", ")));
+        }
+
+        let pos_x = right_captions
+            .iter()
+            .filter_map(|c| root.estimate_text_size(c, &caption_style).ok())
+            .map(|(size, _)| size)
+            .max()
+            .map_or(0, |max_size| (root.dim_in_pixel().0 - max_size) as i32);
+        let mut pos_y = 60;
+
+        for caption in right_captions.iter().rev() {
+            root.draw_text(caption, &caption_style, (pos_x, pos_y))?;
+            pos_y -= 25;
         }
 
         root.present()?;

--- a/src/dovi/plotter.rs
+++ b/src/dovi/plotter.rs
@@ -28,13 +28,15 @@ const NOTO_SANS_REGULAR: &[u8] = include_bytes!(concat!(
 
 const MAX_COLOR: RGBColor = RGBColor(65, 105, 225);
 const AVERAGE_COLOR: RGBColor = RGBColor(75, 0, 130);
-const COLORS: [RGBColor; 6] = [
+const COLORS: [RGBColor; 8] = [
     RGBColor(220, 38, 38),  // red
     RGBColor(234, 179, 8),  // yellow
     RGBColor(34, 197, 94),  // green
     RGBColor(34, 211, 238), // cyan
     RGBColor(59, 130, 246), // blue
     RGBColor(236, 72, 153), // magenta
+    RGBColor(249, 115, 22), // orange
+    RGBColor(139, 92, 246), // purple
 ];
 
 type Series<T> = (&'static str, fn(&T) -> f64, (f64, f64, f64));
@@ -229,9 +231,15 @@ impl Plotter {
             )?;
         }
 
+        let caption_md = if let Some(l9_mdp) = &summary.l9_mdp {
+            format!("{} - {}", summary.rpu_mastering_meta_str, l9_mdp.join(", "))
+        } else {
+            summary.rpu_mastering_meta_str
+        };
+
         let caption_style = ("sans-serif", 24).into_text_style(&root);
         root.draw_text(&chart_caption, &caption_style, (60, 10))?;
-        root.draw_text(&summary.rpu_mastering_meta_str, &caption_style, (60, 35))?;
+        root.draw_text(&caption_md, &caption_style, (60, 35))?;
         root.draw_text(
             &format!("L6 metadata: {l6_meta_str}"),
             &caption_style,
@@ -378,7 +386,7 @@ impl Plotter {
         let data = summary.l8_data.as_ref().unwrap();
         let stats = summary.l8_stats_trims.as_ref().unwrap();
 
-        let series: [Series<ExtMetadataBlockLevel8>; 6] = [
+        let series: [Series<ExtMetadataBlockLevel8>; 8] = [
             ("slope (gain)", |e| e.trim_slope as f64, stats.slope),
             ("offset (lift)", |e| e.trim_offset as f64, stats.offset),
             ("power (gamma)", |e| e.trim_power as f64, stats.power),
@@ -393,6 +401,16 @@ impl Plotter {
                 stats.saturation,
             ),
             ("ms (weight)", |e| e.ms_weight as f64, stats.ms_weight),
+            (
+                "mid (contrast)",
+                |e| e.target_mid_contrast as f64,
+                stats.target_mid_contrast.unwrap(),
+            ),
+            (
+                "clip (trim)",
+                |e| e.clip_trim as f64,
+                stats.clip_trim.unwrap(),
+            ),
         ];
 
         Self::draw_line_series(chart, data, &series)


### PR DESCRIPTION
This MR introduces two functional updates:

### 1. `--plot-type` option for `plot`

Adds support for plotting based on `L2` and `L8` metadata.

```
  -p, --plot-type <PLOT_TYPE>
          Sets the DV metadata level to plot

          [default: l1]

          Possible values:
          - l1:  L1 Dynamic Brightness
          - l2:  L2 Trims
          - l8t: L8 Trims (CM v4.0 RPU required)
          - l8s: L8 Saturation Vectors (CM v4.0 RPU required)
          - l8h: L8 Hue Vectors (CM v4.0 RPU required)
```

### 2. Extended metadata info in summary and plots

Additional metadata fields are now included in both the `info -s` and `plot` annotations:
- **L5 offsets**
- **L8 trims** (for `CM v4.0` **RPUs** only)
- **L9 MDP** (for `CM v4.0` **RPUs** only)

### Examples: 

#### 1. `info -s`

Current **CM v2.9**:
```
Summary:
  Frames: 147955
  Profile: 8
  DM version: 1 (CM v2.9)
  Scene/shot count: 1348
  RPU mastering display: 0.0001/1000 nits
  RPU content light level (L1): MaxCLL: 10000.00 nits, MaxFALL: 43.04 nits
  L6 metadata: Mastering display: 0.0001/1000 nits. MaxCLL: 0 nits, MaxFALL: 0 nits
```

Current **CM v4.0**:
```
Summary:
  Frames: 147955
  Profile: 8
  DM version: 2 (CM v4.0)
  Scene/shot count: 1348
  RPU mastering display: 0.0001/1000 nits
  RPU content light level (L1): MaxCLL: 1023.27 nits, MaxFALL: 92.36 nits
  L6 metadata: Mastering display: 0.0001/1000 nits. MaxCLL: 1023 nits, MaxFALL: 92 nits
  L2 trims: 100 nits
```

New **CM v2.9 + L5 0**:
```
Summary:
  Frames: 147955
  Profile: 8
  DM version: 1 (CM v2.9)
  Scene/shot count: 1348
  RPU mastering display: 0.0001/1000 nits
  RPU content light level (L1): MaxCLL: 10000.00 nits, MaxFALL: 43.04 nits
  L6 metadata: Mastering display: 0.0001/1000 nits. MaxCLL: 0 nits, MaxFALL: 0 nits
  L5 offsets: TOP: 0, BOTTOM: 0, LEFT: 0, RIGHT: 0
```

New **CM v2.9 + L5 Standard**:
```
Summary:
  Frames: 147955
  Profile: 8
  DM version: 1 (CM v2.9)
  Scene/shot count: 1348
  RPU mastering display: 0.0001/1000 nits
  RPU content light level (L1): MaxCLL: 10000.00 nits, MaxFALL: 43.04 nits
  L6 metadata: Mastering display: 0.0001/1000 nits. MaxCLL: 0 nits, MaxFALL: 0 nits
  L5 offsets: TOP: 42, BOTTOM: 42, LEFT: 0, RIGHT: 0
```

New **CM v2.9 + L5 Variable Top/Bottom**:
```
Summary:
  Frames: 147955
  Profile: 8
  DM version: 1 (CM v2.9)
  Scene/shot count: 1348
  RPU mastering display: 0.0001/1000 nits
  RPU content light level (L1): MaxCLL: 10000.00 nits, MaxFALL: 43.04 nits
  L6 metadata: Mastering display: 0.0001/1000 nits. MaxCLL: 0 nits, MaxFALL: 0 nits
  L5 offsets: TOP: (0 - 280), BOTTOM: (0 - 280), LEFT: 0, RIGHT: 0
```

New **CM v4.0 + L5 Null**:
```
Summary:
  Frames: 147955
  Profile: 8
  DM version: 2 (CM v4.0)
  Scene/shot count: 1348
  RPU mastering display: 0.0001/1000 nits
  RPU content light level (L1): MaxCLL: 1023.27 nits, MaxFALL: 92.36 nits
  L6 metadata: Mastering display: 0.0001/1000 nits. MaxCLL: 1023 nits, MaxFALL: 92 nits
  L5 offsets: TOP: N/A, BOTTOM: N/A, LEFT: N/A, RIGHT: N/A
  L2 trims: 100 nits
  L8 trims: 100 nits
  L9 MDP: DCI-P3 D65
```

New **CM v4.0 + L5 Variable**:
```
Summary:
  Frames: 147955
  Profile: 8
  DM version: 2 (CM v4.0)
  Scene/shot count: 1348
  RPU mastering display: 0.0001/1000 nits
  RPU content light level (L1): MaxCLL: 1023.27 nits, MaxFALL: 92.36 nits
  L6 metadata: Mastering display: 0.0001/1000 nits. MaxCLL: 1023 nits, MaxFALL: 92 nits
  L5 offsets: TOP: (0 - 280), BOTTOM: (0 - 280), LEFT: (0 - 60), RIGHT: (0 - 60)
  L2 trims: 100 nits
  L8 trims: 100 nits
  L9 MDP: DCI-P3 D65
```

#### 2. `plot`

Current **CM v2.9**:
![L1_CM29](https://github.com/user-attachments/assets/39460b82-63d6-4b4f-bc11-33fce157e56f)

Current **CM v4.0**:
![L1_CM40](https://github.com/user-attachments/assets/45e81c3f-3c44-4f60-a6e2-024ae6d51b40)

New **CM v2.9 + L5 0**:
![L1_CM29_L5-0](https://github.com/user-attachments/assets/5999cafa-c339-4091-b10b-839dc490aa58)

New **CM v2.9 + L5 Variable Top/Bottom**:
![L1_CM29_L5-VARIABLE-TB](https://github.com/user-attachments/assets/95d2378f-600e-4541-93df-7b71f74748fb)

New **CM v4.0 + L5 Null**:
![L1_CM40_L5-NULL](https://github.com/user-attachments/assets/ab789bb1-8f35-47a9-adc1-14894bab3c87)

#### 2. `plot --plot-type l2`

New **CM v2.9 + L5 Standard** (flat chart, no manual trims):
![L2_CM29_L5-STANDARD](https://github.com/user-attachments/assets/db3d6690-4785-42c5-8a23-d263be8cc9aa)

New **CM v4.0 + L5 Variable**:
![L2_CM40_L5-VARIABLE](https://github.com/user-attachments/assets/a27bcf45-f473-4a90-b948-281f33cdf100)

New **CM v4.0 + L5 Standard**:
![L2_CM40_L5-STANDARD](https://github.com/user-attachments/assets/10e90706-56c6-4fd8-a4be-4e87fe4f0fab)

#### 3. `plot --plot-type l8t`
![L8-trims_plot](https://github.com/user-attachments/assets/19d715f3-ad54-4342-9166-719865bc720f)

#### 4. `plot --plot-type l8s`
![L8-saturation_plot](https://github.com/user-attachments/assets/ebfeb453-85cd-419c-a333-1358d5a04200)

#### 5. `plot --plot-type l8h`
![L8-hue_plot](https://github.com/user-attachments/assets/01b88caf-36a4-402f-8ad0-0cbe06dcb9e3)

