### PR TITLE
Resolve issues in C FFI and RPU parsing

### DIFF
--- a/dolby_vision/CHANGELOG.md
+++ b/dolby_vision/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `GenerateConfig`: list encoding helpers now return iterators instead of a `Vec`.
   - The iterators do not filter out errors anymore.  
     `collect_encoded_rpus` was added for convenience to reproduce previous behaviour.
+- `From<u64> for DoviMappingMethod` was replaced by `TryFrom`.
 
 ## 3.3.2
 - `rpu`: fix `write_rpu_data` allocated capacity. Now static and 512 bytes.

--- a/dolby_vision/src/c_structs/buffers.rs
+++ b/dolby_vision/src/c_structs/buffers.rs
@@ -267,8 +267,10 @@ impl<const N: usize> From<Option<[u16; N]>> for U16Data {
 
 impl Freeable for Data {
     unsafe fn free(&self) {
-        unsafe {
-            Vec::from_raw_parts(self.data as *mut u8, self.len, self.len);
+        if !self.data.is_null() {
+            unsafe {
+                Vec::from_raw_parts(self.data as *mut u8, self.len, self.len);
+            }
         }
     }
 }
@@ -295,8 +297,10 @@ impl Freeable for U64Data {
 
 impl Freeable for I64Data {
     unsafe fn free(&self) {
-        unsafe {
-            Vec::from_raw_parts(self.data as *mut i64, self.len, self.len);
+        if !self.data.is_null() {
+            unsafe {
+                Vec::from_raw_parts(self.data as *mut i64, self.len, self.len);
+            }
         }
     }
 }

--- a/dolby_vision/src/c_structs/extension_metadata.rs
+++ b/dolby_vision/src/c_structs/extension_metadata.rs
@@ -129,24 +129,43 @@ impl DmData {
     }
 
     /// # Safety
+    /// All non-null pointers must have been allocated by Box::into_raw.
     pub unsafe fn free(&self) {
         unsafe {
-            drop(Box::from_raw(self.level1 as *mut ExtMetadataBlockLevel1));
+            if !self.level1.is_null() {
+                drop(Box::from_raw(self.level1 as *mut ExtMetadataBlockLevel1));
+            }
             self.level2.free();
-            drop(Box::from_raw(self.level3 as *mut ExtMetadataBlockLevel3));
-            drop(Box::from_raw(self.level4 as *mut ExtMetadataBlockLevel4));
-            drop(Box::from_raw(self.level5 as *mut ExtMetadataBlockLevel5));
-            drop(Box::from_raw(self.level6 as *mut ExtMetadataBlockLevel6));
+            if !self.level3.is_null() {
+                drop(Box::from_raw(self.level3 as *mut ExtMetadataBlockLevel3));
+            }
+            if !self.level4.is_null() {
+                drop(Box::from_raw(self.level4 as *mut ExtMetadataBlockLevel4));
+            }
+            if !self.level5.is_null() {
+                drop(Box::from_raw(self.level5 as *mut ExtMetadataBlockLevel5));
+            }
+            if !self.level6.is_null() {
+                drop(Box::from_raw(self.level6 as *mut ExtMetadataBlockLevel6));
+            }
             self.level8.free();
-            drop(Box::from_raw(self.level9 as *mut ExtMetadataBlockLevel9));
+            if !self.level9.is_null() {
+                drop(Box::from_raw(self.level9 as *mut ExtMetadataBlockLevel9));
+            }
             self.level10.free();
-            drop(Box::from_raw(self.level11 as *mut ExtMetadataBlockLevel11));
-            drop(Box::from_raw(
-                self.level254 as *mut ExtMetadataBlockLevel254,
-            ));
-            drop(Box::from_raw(
-                self.level255 as *mut ExtMetadataBlockLevel255,
-            ));
+            if !self.level11.is_null() {
+                drop(Box::from_raw(self.level11 as *mut ExtMetadataBlockLevel11));
+            }
+            if !self.level254.is_null() {
+                drop(Box::from_raw(
+                    self.level254 as *mut ExtMetadataBlockLevel254,
+                ));
+            }
+            if !self.level255.is_null() {
+                drop(Box::from_raw(
+                    self.level255 as *mut ExtMetadataBlockLevel255,
+                ));
+            }
         }
     }
 }

--- a/dolby_vision/src/c_structs/rpu.rs
+++ b/dolby_vision/src/c_structs/rpu.rs
@@ -27,19 +27,23 @@ pub struct RpuOpaqueList {
 }
 
 impl RpuOpaque {
-    pub(crate) fn new(rpu: Option<DoviRpu>, error: Option<CString>) -> Self {
-        Self { rpu, error }
+    pub(crate) fn new(rpu: Option<DoviRpu>) -> Self {
+        Self { rpu, error: None }
+    }
+
+    pub(crate) fn invalid_with_error(msg: &str) -> Self {
+        Self {
+            rpu: None,
+            error: CString::new(msg).ok(),
+        }
     }
 }
 
 impl From<Result<DoviRpu, anyhow::Error>> for RpuOpaque {
     fn from(res: Result<DoviRpu, anyhow::Error>) -> Self {
         match res {
-            Ok(rpu) => Self::new(Some(rpu), None),
-            Err(e) => Self::new(
-                None,
-                Some(CString::new(format!("Failed parsing RPU: {e}")).unwrap()),
-            ),
+            Ok(rpu) => Self::new(Some(rpu)),
+            Err(e) => Self::invalid_with_error(&format!("Failed parsing RPU: {e}")),
         }
     }
 }

--- a/dolby_vision/src/capi.rs
+++ b/dolby_vision/src/capi.rs
@@ -19,7 +19,12 @@ use super::c_structs::*;
 /// Adds an error if the parsing fails.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn dovi_parse_rpu(buf: *const u8, len: size_t) -> *mut RpuOpaque {
-    assert!(!buf.is_null());
+    if buf.is_null() {
+        return Box::into_raw(Box::new(RpuOpaque::new(
+            None,
+            CString::new("dovi_parse_rpu: null buffer pointer").ok(),
+        )));
+    }
 
     let data = unsafe { slice::from_raw_parts(buf, len) };
     let res = DoviRpu::parse_rpu(data);
@@ -37,7 +42,12 @@ pub unsafe extern "C" fn dovi_parse_itu_t35_dovi_metadata_obu(
     buf: *const u8,
     len: size_t,
 ) -> *mut RpuOpaque {
-    assert!(!buf.is_null());
+    if buf.is_null() {
+        return Box::into_raw(Box::new(RpuOpaque::new(
+            None,
+            CString::new("dovi_parse_itu_t35_dovi_metadata_obu: null buffer pointer").ok(),
+        )));
+    }
 
     let data = unsafe { slice::from_raw_parts(buf, len) };
     let res = DoviRpu::parse_itu_t35_dovi_metadata_obu(data);
@@ -52,7 +62,12 @@ pub unsafe extern "C" fn dovi_parse_itu_t35_dovi_metadata_obu(
 /// Adds an error if the parsing fails.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn dovi_parse_unspec62_nalu(buf: *const u8, len: size_t) -> *mut RpuOpaque {
-    assert!(!buf.is_null());
+    if buf.is_null() {
+        return Box::into_raw(Box::new(RpuOpaque::new(
+            None,
+            CString::new("dovi_parse_unspec62_nalu: null buffer pointer").ok(),
+        )));
+    }
 
     let data = unsafe { slice::from_raw_parts(buf, len) };
     let res = DoviRpu::parse_unspec62_nalu(data);

--- a/dolby_vision/src/capi.rs
+++ b/dolby_vision/src/capi.rs
@@ -20,9 +20,8 @@ use super::c_structs::*;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn dovi_parse_rpu(buf: *const u8, len: size_t) -> *mut RpuOpaque {
     if buf.is_null() {
-        return Box::into_raw(Box::new(RpuOpaque::new(
-            None,
-            CString::new("dovi_parse_rpu: null buffer pointer").ok(),
+        return Box::into_raw(Box::new(RpuOpaque::invalid_with_error(
+            "dovi_parse_rpu: null buffer pointer",
         )));
     }
 
@@ -43,9 +42,8 @@ pub unsafe extern "C" fn dovi_parse_itu_t35_dovi_metadata_obu(
     len: size_t,
 ) -> *mut RpuOpaque {
     if buf.is_null() {
-        return Box::into_raw(Box::new(RpuOpaque::new(
-            None,
-            CString::new("dovi_parse_itu_t35_dovi_metadata_obu: null buffer pointer").ok(),
+        return Box::into_raw(Box::new(RpuOpaque::invalid_with_error(
+            "dovi_parse_itu_t35_dovi_metadata_obu: null buffer pointer",
         )));
     }
 
@@ -63,9 +61,8 @@ pub unsafe extern "C" fn dovi_parse_itu_t35_dovi_metadata_obu(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn dovi_parse_unspec62_nalu(buf: *const u8, len: size_t) -> *mut RpuOpaque {
     if buf.is_null() {
-        return Box::into_raw(Box::new(RpuOpaque::new(
-            None,
-            CString::new("dovi_parse_unspec62_nalu: null buffer pointer").ok(),
+        return Box::into_raw(Box::new(RpuOpaque::invalid_with_error(
+            "dovi_parse_unspec62_nalu: null buffer pointer",
         )));
     }
 
@@ -139,8 +136,7 @@ pub unsafe extern "C" fn dovi_write_rpu(ptr: *mut RpuOpaque) -> *const Data {
         match rpu.write_rpu() {
             Ok(buf) => Box::into_raw(Box::new(Data::from(buf))),
             Err(e) => {
-                opaque.error =
-                    Some(CString::new(format!("Failed writing byte buffer: {e}")).unwrap());
+                opaque.error = CString::new(format!("Failed writing byte buffer: {e}")).ok();
                 null_mut()
             }
         }
@@ -166,8 +162,7 @@ pub unsafe extern "C" fn dovi_write_unspec62_nalu(ptr: *mut RpuOpaque) -> *const
         match rpu.write_hevc_unspec62_nalu() {
             Ok(buf) => Box::into_raw(Box::new(Data::from(buf))),
             Err(e) => {
-                opaque.error =
-                    Some(CString::new(format!("Failed writing byte buffer: {e}")).unwrap());
+                opaque.error = CString::new(format!("Failed writing byte buffer: {e}")).ok();
                 null_mut()
             }
         }
@@ -206,7 +201,7 @@ pub unsafe extern "C" fn dovi_convert_rpu_with_mode(ptr: *mut RpuOpaque, mode: u
             Ok(_) => 0,
             Err(e) => {
                 opaque.error =
-                    Some(CString::new(format!("Failed converting with mode {mode}: {e}")).unwrap());
+                    CString::new(format!("Failed converting with mode {mode}: {e}")).ok();
                 -1
             }
         }
@@ -352,7 +347,7 @@ pub unsafe extern "C" fn dovi_parse_rpu_bin_file(path: *const c_char) -> *const 
 
                         let opaque_list: Vec<*mut RpuOpaque> = rpus
                             .into_iter()
-                            .map(|rpu| Box::into_raw(Box::new(RpuOpaque::new(Some(rpu), None))))
+                            .map(|rpu| Box::into_raw(Box::new(RpuOpaque::new(Some(rpu)))))
                             .collect();
 
                         rpu_list.list =
@@ -370,8 +365,8 @@ pub unsafe extern "C" fn dovi_parse_rpu_bin_file(path: *const c_char) -> *const 
                 Some("parse_rpu_bin_file: Failed parsing the input path as a string".to_string());
         }
 
-        if let Some(err) = error {
-            rpu_list.error = CString::new(err).unwrap().into_raw();
+        if let Some(err) = error.and_then(|err| CString::new(err).ok()) {
+            rpu_list.error = err.into_raw();
         }
 
         return Box::into_raw(Box::new(rpu_list));
@@ -418,7 +413,7 @@ pub unsafe extern "C" fn dovi_rpu_set_active_area_offsets(
             Ok(_) => 0,
             Err(e) => {
                 opaque.error =
-                    Some(CString::new(format!("Failed editing active area offsets: {e}")).unwrap());
+                    CString::new(format!("Failed editing active area offsets: {e}")).ok();
                 -1
             }
         }
@@ -467,8 +462,7 @@ pub unsafe extern "C" fn dovi_write_av1_rpu_metadata_obu_t35_payload(
         match rpu.write_av1_rpu_metadata_obu_t35_payload() {
             Ok(buf) => Box::into_raw(Box::new(Data::from(buf))),
             Err(e) => {
-                opaque.error =
-                    Some(CString::new(format!("Failed writing byte buffer: {e}")).unwrap());
+                opaque.error = CString::new(format!("Failed writing byte buffer: {e}")).ok();
                 null_mut()
             }
         }
@@ -496,8 +490,7 @@ pub unsafe extern "C" fn dovi_write_av1_rpu_metadata_obu_t35_complete(
         match rpu.write_av1_rpu_metadata_obu_t35_complete() {
             Ok(buf) => Box::into_raw(Box::new(Data::from(buf))),
             Err(e) => {
-                opaque.error =
-                    Some(CString::new(format!("Failed writing byte buffer: {e}")).unwrap());
+                opaque.error = CString::new(format!("Failed writing byte buffer: {e}")).ok();
                 null_mut()
             }
         }

--- a/dolby_vision/src/rpu/dovi_rpu.rs
+++ b/dolby_vision/src/rpu/dovi_rpu.rs
@@ -116,6 +116,10 @@ impl DoviRpu {
 
         // Ignore trailing bytes
         let rpu_end = data.len() - trailing_zeroes;
+
+        // Minimum: 1 prefix byte + at least 1 byte payload + 4 CRC32 bytes + 1 final byte = 7
+        ensure!(rpu_end >= 7, "RPU data too short: {rpu_end} bytes after trimming trailing zeroes");
+
         let last_byte = data[rpu_end - 1];
 
         // Minus 4 bytes for the CRC32, 1 for the 0x80 ending byte

--- a/dolby_vision/src/rpu/dovi_rpu.rs
+++ b/dolby_vision/src/rpu/dovi_rpu.rs
@@ -118,7 +118,10 @@ impl DoviRpu {
         let rpu_end = data.len() - trailing_zeroes;
 
         // Minimum: 1 prefix byte + at least 1 byte payload + 4 CRC32 bytes + 1 final byte = 7
-        ensure!(rpu_end >= 7, "RPU data too short: {rpu_end} bytes after trimming trailing zeroes");
+        ensure!(
+            rpu_end >= 7,
+            "RPU data too short: {rpu_end} bytes after trimming trailing zeroes"
+        );
 
         let last_byte = data[rpu_end - 1];
 

--- a/dolby_vision/src/rpu/rpu_data_mapping.rs
+++ b/dolby_vision/src/rpu/rpu_data_mapping.rs
@@ -150,7 +150,7 @@ impl RpuDataMapping {
             let num_pieces = (curve.num_pivots_minus2 + 1) as usize;
 
             for _ in 0..num_pieces {
-                let mapping_idc = DoviMappingMethod::from(reader.read_ue()?);
+                let mapping_idc = DoviMappingMethod::try_from(reader.read_ue()?)?;
                 curve.mapping_idc = mapping_idc;
 
                 // MAPPING_POLYNOMIAL
@@ -525,12 +525,14 @@ impl DoviMMRCurve {
     }
 }
 
-impl From<u64> for DoviMappingMethod {
-    fn from(value: u64) -> Self {
+impl TryFrom<u64> for DoviMappingMethod {
+    type Error = anyhow::Error;
+
+    fn try_from(value: u64) -> Result<Self> {
         match value {
-            0 => Self::Polynomial,
-            1 => Self::MMR,
-            _ => unreachable!(),
+            0 => Ok(Self::Polynomial),
+            1 => Ok(Self::MMR),
+            _ => bail!("Invalid mapping_idc value: {value}"),
         }
     }
 }


### PR DESCRIPTION
This merge request addresses 6 findings from a security audit targeting undefined behavior, panics across FFI boundaries, and arithmetic underflows in the dolby_vision crate.

--------------------------------------------------------------------------------

- File: dolby_vision/src/c_structs/extension_metadata.rs
- Root cause: DmData::free() unconditionally called Box::from_raw() on every
  level pointer (level1, level3, level4, level5, level6, level9, level11,
  level254, level255), but these pointers are initialized to null() in
  Default::default(). Calling Box::from_raw on a null pointer is instant
  undefined behavior per the Rust reference.
- Fix: Added null checks (if !self.levelN.is_null()) before each
  Box::from_raw call, matching the existing pattern used by level2, level8,
  and level10 which already go through their own free() methods with guards.

--------------------------------------------------------------------------------

- File: dolby_vision/src/c_structs/buffers.rs (Data::free)
- Root cause: The Freeable implementation for Data called
  Vec::from_raw_parts(self.data, ...) without checking if self.data is null.
  Vec::from_raw_parts requires a non-null, properly aligned pointer.
  Inconsistently, U16Data::free() and U64Data::free() already had null checks.
- Fix: Added if !self.data.is_null() guard around the Vec::from_raw_parts
  call, matching the pattern already used by U16Data and U64Data.

--------------------------------------------------------------------------------

- File: dolby_vision/src/c_structs/buffers.rs (I64Data::free)
- Root cause: Same issue as Data::free() above. The Freeable implementation
  for I64Data called Vec::from_raw_parts without null-checking self.data first.
- Fix: Added if !self.data.is_null() guard around the Vec::from_raw_parts
  call, consistent with the other buffer types.

--------------------------------------------------------------------------------

- File: dolby_vision/src/capi.rs
- Root cause: dovi_parse_itu_t35_dovi_metadata_obu() and
  dovi_parse_unspec62_nalu() used assert!(!buf.is_null()) to validate
  input pointers. A failed assert! triggers a Rust panic, and unwinding
  across an extern "C" FFI boundary is undefined behavior. The first
  function dovi_parse_rpu() was already fixed in a prior edit.
- Fix: Replaced both assert! calls with explicit null checks that return an
  RpuOpaque containing a descriptive error message, matching the pattern
  already established in dovi_parse_rpu(). This allows C callers to detect
  the error via dovi_rpu_get_error() instead of crashing.

--------------------------------------------------------------------------------

- File: dolby_vision/src/rpu/rpu_data_mapping.rs
- Root cause: The From<u64> implementation for DoviMappingMethod used
  unreachable!() for any value other than 0 or 1. Since mapping_idc is
  read from untrusted bitstream data via read_ue(), a malformed input can
  supply any u64 value, triggering a panic that aborts the process.
- Fix: Changed From<u64> to TryFrom<u64> returning an anyhow::Error with a
  descriptive message for invalid values. Updated the call site to use
  try_from()? so the error propagates gracefully through the Result chain.

--------------------------------------------------------------------------------

- File: dolby_vision/src/rpu/dovi_rpu.rs
- Root cause: DoviRpu::parse() computes rpu_end = data.len() - trailing_zeroes,
  then accesses data[rpu_end - 1] and computes crc32_start = rpu_end - 5.
  If the input is all zeroes or shorter than 7 bytes, rpu_end can be 0,
  causing arithmetic underflow (panic in debug, silent wrap in release)
  and subsequent out-of-bounds access.
- Fix: Added an ensure!(rpu_end >= 7, ...) check immediately after computing
  rpu_end. The minimum of 7 accounts for 1 prefix byte + 1 byte payload +
  4 CRC32 bytes + 1 final byte (0x80). This returns a descriptive error
  instead of panicking or silently wrapping.