### PR TITLE
expose GenerateConfig via JSON C API

### DIFF
--- a/dolby_vision/src/capi.rs
+++ b/dolby_vision/src/capi.rs
@@ -10,6 +10,9 @@ use std::{
 
 use crate::rpu::{ConversionMode, dovi_rpu::DoviRpu, utils::parse_rpu_file};
 
+#[cfg(feature = "serde")]
+use crate::rpu::generate::GenerateConfig;
+
 use super::c_structs::*;
 
 /// # Safety
@@ -527,4 +530,65 @@ pub unsafe extern "C" fn dovi_write_av1_rpu_metadata_obu_t35_complete(
     } else {
         null_mut()
     }
+}
+
+/// # Safety
+/// The JSON string pointer must be valid.
+///
+/// Generates RPUs from a JSON serialized `GenerateConfig`.
+/// Returns the heap allocated `DoviRpuOpaqueList` as a pointer.
+/// The returned pointer may be null, or the list could be empty if an error occurred.
+///
+/// Requires the `serde` feature.
+///
+/// Free with `dovi_rpu_list_free`.
+#[cfg(feature = "serde")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dovi_generate_from_json(json: *const c_char) -> *const RpuOpaqueList {
+    if json.is_null() {
+        return null();
+    }
+
+    let mut rpu_list = RpuOpaqueList {
+        list: null(),
+        len: 0,
+        error: null(),
+    };
+    let mut error = None;
+
+    let json_str = match unsafe { CStr::from_ptr(json) }.to_str() {
+        Ok(s) => s,
+        Err(e) => {
+            error = Some(format!("dovi_generate_from_json: invalid UTF-8: {e}"));
+            let err = error.and_then(|err| CString::new(err).ok());
+            if let Some(err) = err {
+                rpu_list.error = err.into_raw();
+            }
+            return Box::into_raw(Box::new(rpu_list));
+        }
+    };
+
+    match serde_json::from_str::<GenerateConfig>(json_str) {
+        Ok(config) => match config.generate_rpu_list() {
+            Ok(rpus) => {
+                rpu_list.len = rpus.len();
+
+                let opaque_list: Vec<*mut RpuOpaque> = rpus
+                    .into_iter()
+                    .map(|rpu| Box::into_raw(Box::new(RpuOpaque::new(Some(rpu)))))
+                    .collect();
+
+                rpu_list.list =
+                    Box::into_raw(opaque_list.into_boxed_slice()) as *const *mut RpuOpaque;
+            }
+            Err(e) => error = Some(format!("dovi_generate_from_json: generation failed: {e}")),
+        },
+        Err(e) => error = Some(format!("dovi_generate_from_json: invalid JSON: {e}")),
+    }
+
+    if let Some(err) = error.and_then(|err| CString::new(err).ok()) {
+        rpu_list.error = err.into_raw();
+    }
+
+    Box::into_raw(Box::new(rpu_list))
 }


### PR DESCRIPTION
Per discussion: single function that takes a JSON string, deserializes to GenerateConfig, generates RPUs, returns RpuOpaqueList. Same return type as dovi_parse_rpu_bin_file.

```c
const char* json = "{\"profile\": \"8.1\", \"cm_version\": \"V40\", ...}";
const DoviRpuOpaqueList* list = dovi_generate_from_json(json);
```

Gated on `capi` + `serde` features. serde_json dependency was already there.

Our use case (HDR10+ to P8.1, RPU writer code from cpm/avdvplus): build the JSON config per frame with L1 values from HDR10+ conversion, generate one RPU, write it. Replaces ~280 lines of hand-written RPU bitstream in C++.