### PR TITLE
capi: add dovi_rpu_remove_cmv40_metadata (strip CMv4.0 to CMv2.9)

### DIFF
--- a/dolby_vision/src/capi.rs
+++ b/dolby_vision/src/capi.rs
@@ -479,6 +479,35 @@ pub unsafe extern "C" fn dovi_rpu_add_cmv40_safe_default_metadata(ptr: *mut RpuO
 /// # Safety
 /// The struct pointer must be valid.
 ///
+/// Removes the CMv4.0 extension metadata from the RPU, leaving a CMv2.9-only RPU.
+/// Does nothing if CMv4.0 metadata is not present.
+///
+/// Returns 0 on success, -1 on error.
+/// If an error occurs, it is logged to RpuOpaque.error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dovi_rpu_remove_cmv40_metadata(ptr: *mut RpuOpaque) -> i32 {
+    if ptr.is_null() {
+        return -1;
+    }
+
+    let opaque = unsafe { &mut *ptr };
+
+    if let Some(rpu) = &mut opaque.rpu {
+        match rpu.remove_cmv40_extension_metadata() {
+            Ok(_) => 0,
+            Err(e) => {
+                opaque.error = CString::new(format!("Failed removing CMv4.0 metadata: {e}")).ok();
+                -1
+            }
+        }
+    } else {
+        -1
+    }
+}
+
+/// # Safety
+/// The struct pointer must be valid.
+///
 /// Writes the encoded RPU as `itu_t_t35_payload_bytes` for AV1 ITU-T T.35 metadata OBU
 /// If an error occurs in the writing, it is logged to RpuOpaque.error
 #[unsafe(no_mangle)]


### PR DESCRIPTION
Exposes the existing `DoviRpu::remove_cmv40_extension_metadata()` through the C API. It mirrors `dovi_rpu_add_cmv40_safe_default_metadata` from #393.

It strips the CMv4.0 extension metadata from a parsed RPU and leaves a CMv2.9-only RPU. No-op when no CMv4.0 is present. Returns `0` on success and `-1` on error, same as `dovi_rpu_remove_mapping`.

### Why
On Amlogic (CoreELEC/Kodi), some old Dolby Vision TVs do not fall back from CMv4.0 and just black-screen on CMv4.0 content. Handing them a plain CMv2.9 RPU (parse, remove, write back) gets them a picture, and it keeps the bitstream work inside libdovi like the append path does.

### Notes
- Thin wrapper. The underlying `remove_cmv40_extension_metadata()` already exists and is covered by the editor `--remove-cmv4` path (`rpu::editor::remove_cmv4`). Nothing existing changes.
- Tested locally with `cargo build --features capi` and `cargo test --no-default-features --features internal-font --test mod editor` (8/8, including `remove_cmv4`).
- I followed your `add_*`/`remove_*` naming, but rename it if you would rather, same as #393.