### PR TITLE
fix: correct occured→occurred typo in build.rs error message

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
         .and_then(|emitter| emitter.emit());
 
     if let Err(e) = gitcl_res {
-        eprintln!("error occured while generating instructions: {e:?}");
+        eprintln!("error occurred while generating instructions: {e:?}");
         Emitter::default().idempotent().fail_on_error().emit()?;
     }
 


### PR DESCRIPTION
## Summary
Corrected the occured→occurred typo in build.rs error message (line 16).

## Changes
- build.rs: Fixed eprintln error message

## Testing
- cargo check passes