### PR TITLE
cli/hevc: exit with error if input files are not Dolby Vision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,7 @@ dependencies = [
  "predicates",
  "serde",
  "serde_json",
+ "thiserror",
  "vergen-gitcl",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ itertools = "0.14.0"
 plotters = { version = "0.3.7", default-features = false, features = ["bitmap_backend", "bitmap_encoder", "all_series"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.149", features = ["preserve_order"] }
+thiserror = "2.0.18"
 
 [dev-dependencies]
 assert_cmd = "2.2.2"

--- a/src/dovi/demuxer.rs
+++ b/src/dovi/demuxer.rs
@@ -2,7 +2,7 @@ use anyhow::{Result, bail};
 use indicatif::ProgressBar;
 use std::path::PathBuf;
 
-use crate::commands::DemuxArgs;
+use crate::{commands::DemuxArgs, dovi::general_read_write::DoviProcessorError};
 
 use super::{CliOptions, IoFormat, general_read_write, input_from_either};
 
@@ -68,8 +68,9 @@ impl Demuxer {
         } else {
             Some(self.bl_out.as_path())
         };
+        let el_out = self.el_out.as_path();
 
-        let dovi_writer = DoviWriter::new(bl_out, Some(self.el_out.as_path()), None, None);
+        let dovi_writer = DoviWriter::new(bl_out, Some(el_out), None, None);
         let mut dovi_processor = DoviProcessor::new(
             options,
             self.input.clone(),
@@ -78,6 +79,18 @@ impl Demuxer {
             Default::default(),
         );
 
-        dovi_processor.read_write_from_io(&self.format)
+        let res = dovi_processor.read_write_from_io(&self.format);
+
+        if res.as_ref().is_err_and(|err| {
+            err.downcast_ref::<DoviProcessorError>()
+                .is_some_and(|e| matches!(e, DoviProcessorError::NoElFound))
+        }) {
+            if let Some(bl_out) = bl_out {
+                std::fs::remove_file(bl_out)?;
+            }
+            std::fs::remove_file(el_out)?;
+        }
+
+        res
     }
 }

--- a/src/dovi/general_read_write.rs
+++ b/src/dovi/general_read_write.rs
@@ -13,6 +13,16 @@ use processor::{HevcProcessor, HevcProcessorOpts};
 use super::hdr10plus_utils::prefix_sei_removed_hdr10plus_nalu;
 use super::{CliOptions, convert_encoded_from_opts};
 
+#[derive(thiserror::Error, Debug)]
+pub enum DoviProcessorError {
+    #[error("No RPU was found in input file")]
+    NoRpuFound,
+    #[error("No enhancement layer was found in input file")]
+    NoElFound,
+    #[error("Missing frame/slices for metadata! Decoded index {0}")]
+    MissingFrame(usize),
+}
+
 pub struct DoviProcessor {
     input: PathBuf,
     options: CliOptions,
@@ -26,6 +36,7 @@ pub struct DoviProcessor {
     dovi_writer: DoviWriter,
 
     processor_opts: DoviProcessorOptions,
+    state: DoviProcessorState,
 }
 
 pub struct DoviWriter {
@@ -45,6 +56,12 @@ pub struct RpuNal {
 #[derive(Default)]
 pub struct DoviProcessorOptions {
     pub limit: Option<u64>,
+}
+
+#[derive(Default)]
+struct DoviProcessorState {
+    found_rpu: bool,
+    found_el: bool,
 }
 
 impl DoviWriter {
@@ -110,6 +127,7 @@ impl DoviProcessor {
             progress_bar,
             dovi_writer,
             processor_opts,
+            state: Default::default(),
         }
     }
 
@@ -212,6 +230,8 @@ impl DoviProcessor {
 
             match nal.nal_type {
                 NAL_UNSPEC63 => {
+                    self.state.found_el = true;
+
                     if let Some(el_writer) = self.dovi_writer.el_writer.as_mut() {
                         // Can't know for EL, always size 4
                         NALUnit::write_with_preset(
@@ -224,6 +244,8 @@ impl DoviProcessor {
                     }
                 }
                 NAL_UNSPEC62 => {
+                    self.state.found_rpu = true;
+
                     self.previous_rpu_index = nal.decoded_frame_index;
                     let rpu_data = &chunk[nal.start..nal.end];
 
@@ -313,10 +335,7 @@ impl DoviProcessor {
                 if let Some(i) = matching_index {
                     frames[i].presentation_number
                 } else {
-                    panic!(
-                        "Missing frame/slices for metadata! Decoded index {}",
-                        rpu.decoded_index
-                    );
+                    panic!("{}", DoviProcessorError::MissingFrame(rpu.decoded_index));
                 }
             });
 
@@ -345,6 +364,20 @@ impl DoviProcessor {
 
         Ok(())
     }
+
+    fn verify_process_state(&self, parser: &HevcParser) -> Result<()> {
+        // first frame fully parsed
+        if !parser.ordered_frames().is_empty() {
+            if !self.state.found_rpu && self.dovi_writer.rpu_writer.is_some() {
+                bail!(DoviProcessorError::NoRpuFound);
+            }
+            if !self.state.found_el && self.dovi_writer.el_writer.is_some() {
+                bail!(DoviProcessorError::NoElFound);
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl IoProcessor for DoviProcessor {
@@ -356,15 +389,19 @@ impl IoProcessor for DoviProcessor {
         self.progress_bar.inc(delta);
     }
 
-    fn process_nals(&mut self, _parser: &HevcParser, nals: &[NALUnit], chunk: &[u8]) -> Result<()> {
+    fn process_nals(&mut self, parser: &HevcParser, nals: &[NALUnit], chunk: &[u8]) -> Result<()> {
         self.write_nals(chunk, nals)?;
         self.payload_count += 1;
+
+        self.verify_process_state(parser)?;
 
         Ok(())
     }
 
     fn finalize(&mut self, parser: &HevcParser) -> Result<()> {
         self.progress_bar.finish_and_clear();
+        self.verify_process_state(parser)?;
+
         self.flush_writer(parser)
     }
 }

--- a/src/dovi/rpu_extractor.rs
+++ b/src/dovi/rpu_extractor.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use indicatif::ProgressBar;
 use std::path::PathBuf;
 
-use crate::commands::ExtractRpuArgs;
+use crate::{commands::ExtractRpuArgs, dovi::general_read_write::DoviProcessorError};
 
 use super::{
     CliOptions, IoFormat,
@@ -54,7 +54,9 @@ impl RpuExtractor {
     }
 
     fn extract_rpu_from_el(&self, pb: ProgressBar, options: CliOptions) -> Result<()> {
-        let dovi_writer = DoviWriter::new(None, None, Some(&self.rpu_out), None);
+        let rpu_out = self.rpu_out.as_path();
+
+        let dovi_writer = DoviWriter::new(None, None, Some(rpu_out), None);
         let mut dovi_processor = DoviProcessor::new(
             options,
             self.input.clone(),
@@ -63,6 +65,15 @@ impl RpuExtractor {
             DoviProcessorOptions { limit: self.limit },
         );
 
-        dovi_processor.read_write_from_io(&self.format)
+        let res = dovi_processor.read_write_from_io(&self.format);
+
+        if res.as_ref().is_err_and(|err| {
+            err.downcast_ref::<DoviProcessorError>()
+                .is_some_and(|e| matches!(e, DoviProcessorError::NoRpuFound))
+        }) {
+            std::fs::remove_file(rpu_out)?;
+        }
+
+        res
     }
 }

--- a/tests/hevc/demux.rs
+++ b/tests/hevc/demux.rs
@@ -211,3 +211,34 @@ fn annexb() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn demux_el_not_found() -> Result<()> {
+    let mut cmd = cargo::cargo_bin_cmd!();
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    let input_file = Path::new("assets/hevc_tests/regular.hevc");
+    let output_bl = temp.child("BL.hevc");
+    let output_el = temp.child("EL.hevc");
+
+    let assert = cmd
+        .arg(SUBCOMMAND)
+        .arg(input_file)
+        .arg("--bl-out")
+        .arg(output_bl.as_ref())
+        .arg("--el-out")
+        .arg(output_el.as_ref())
+        .assert();
+
+    assert
+        .failure()
+        .stderr(predicate::str::contains(
+            "Error: No enhancement layer was found in input file",
+        ))
+        .stdout(predicate::str::is_empty());
+
+    output_bl.assert(predicate::path::exists().not());
+    output_el.assert(predicate::path::exists().not());
+
+    Ok(())
+}

--- a/tests/hevc/extract_rpu.rs
+++ b/tests/hevc/extract_rpu.rs
@@ -139,3 +139,30 @@ fn extract_rpu_mkv() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn extract_rpu_not_found() -> Result<()> {
+    let mut cmd = cargo::cargo_bin_cmd!();
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    let input_file = Path::new("assets/hevc_tests/regular_bl_start_code_4.hevc");
+    let output_rpu = temp.child("RPU.bin");
+
+    let assert = cmd
+        .arg(SUBCOMMAND)
+        .arg(input_file)
+        .arg("--rpu-out")
+        .arg(output_rpu.as_ref())
+        .assert();
+
+    assert
+        .failure()
+        .stderr(predicate::str::contains(
+            "Error: No RPU was found in input file",
+        ))
+        .stdout(predicate::str::is_empty());
+
+    output_rpu.assert(predicate::path::exists().not());
+
+    Ok(())
+}

--- a/tests/hevc/inject_rpu.rs
+++ b/tests/hevc/inject_rpu.rs
@@ -216,22 +216,18 @@ fn sei_suffix_before_rpu() -> Result<()> {
 
     // Demux
     let output_bl = temp.child("BL.hevc");
-    let output_el = temp.child("EL.hevc");
 
     let mut cmd = cargo::cargo_bin_cmd!();
     let assert = cmd
-        .arg("demux")
+        .arg("remove")
         .arg(input_file)
-        .arg("--bl-out")
+        .arg("--output")
         .arg(output_bl.as_ref())
-        .arg("--el-out")
-        .arg(output_el.as_ref())
         .assert();
 
     assert.success().stderr(predicate::str::is_empty());
 
     output_bl.assert(predicate::path::is_file());
-    output_el.assert(predicate::path::is_file());
 
     // Extract RPU
     let output_rpu = temp.child("RPU.bin");


### PR DESCRIPTION
extract-rpu: when the file doesn't contain any RPU
demux: when the file doesn't contain any enhancement layer NAL

Only the first parsed frame is checked before erroring, as they are supposed to be present for every frame in the bitstream.

Fixes #404

Need analysis to see if it's feasible to avoid creating the empty files initially.
Most likely it isn't as the data is written directly as the file is processed.
Though it could be reasonable to delete the empty files if there's an error..