### PR TITLE
Add Matroska track selection to extract-rpu

### DIFF
--- a/src/commands/extract_rpu.rs
+++ b/src/commands/extract_rpu.rs
@@ -38,4 +38,11 @@ pub struct ExtractRpuArgs {
         help = "Stop processing input after N frames"
     )]
     pub limit: Option<u64>,
+
+    #[arg(
+        long,
+        short = 't',
+        help = "Select Matroska HEVC video track by track number"
+    )]
+    pub track: Option<u64>,
 }

--- a/src/dovi/general_read_write.rs
+++ b/src/dovi/general_read_write.rs
@@ -56,6 +56,7 @@ pub struct RpuNal {
 #[derive(Default)]
 pub struct DoviProcessorOptions {
     pub limit: Option<u64>,
+    pub track: Option<u64>,
 }
 
 #[derive(Default)]
@@ -137,6 +138,7 @@ impl DoviProcessor {
         let processor_opts = HevcProcessorOpts {
             parse_nals: true,
             limit: self.processor_opts.limit,
+            track: self.processor_opts.track,
             ..Default::default()
         };
         let mut processor = HevcProcessor::new(format.clone(), processor_opts, chunk_size);

--- a/src/dovi/rpu_extractor.rs
+++ b/src/dovi/rpu_extractor.rs
@@ -16,6 +16,7 @@ pub struct RpuExtractor {
     input: PathBuf,
     rpu_out: PathBuf,
     limit: Option<u64>,
+    track: Option<u64>,
 }
 
 impl RpuExtractor {
@@ -25,6 +26,7 @@ impl RpuExtractor {
             input_pos,
             rpu_out,
             limit,
+            track,
         } = args;
 
         let input = input_from_either("extract-rpu", input, input_pos)?;
@@ -40,6 +42,7 @@ impl RpuExtractor {
             input,
             rpu_out,
             limit,
+            track,
         })
     }
 
@@ -62,7 +65,10 @@ impl RpuExtractor {
             self.input.clone(),
             dovi_writer,
             pb,
-            DoviProcessorOptions { limit: self.limit },
+            DoviProcessorOptions {
+                limit: self.limit,
+                track: self.track,
+            },
         );
 
         let res = dovi_processor.read_write_from_io(&self.format);


### PR DESCRIPTION
Add -t/--track to extract-rpu to select a specific Matroska HEVC video track.

The selected track number is passed through RpuExtractor and DoviProcessor to the HEVC processor.

When --track is omitted, existing behavior is unchanged.

Depends on https://github.com/quietvoid/hevc_parser/pull/9